### PR TITLE
Add a possibility to use expect+su

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include expect-su.expect

--- a/README.rst
+++ b/README.rst
@@ -21,9 +21,14 @@ Example Synapse config:
       - module: "pam_auth_provider.PAMAuthProvider"
         config:
           create_users: true
+          use_expect: false
 
 The ``create_users``-key specifies whether to create Matrix accounts
 for valid system accounts.
+
+The ``use_expect``-key specifies whether to use expect instead of Python
+PAM package (needs ``expect`` and ``su`` programs, avoids the need for
+root access)
 
 Copyright
 ---------

--- a/expect-su.expect
+++ b/expect-su.expect
@@ -1,0 +1,12 @@
+#!/usr/bin/env expect
+
+lassign $argv user password
+
+spawn "su" "$user" "-s" "/bin/sh" "-c" "true"
+
+expect {
+  "Password:" { send "$password\n" }
+}
+
+lassign [wait] pid spawnid ok code
+exit $code

--- a/setup.py
+++ b/setup.py
@@ -19,8 +19,12 @@ from setuptools import setup
 
 setup(
         name="matrix-synapse-pam",
-        version="0.1.2",
+        version="0.1.3",
         py_modules=['pam_auth_provider'],
+
+        include_package_data = True,
+        data_files = [("share/matrix-synapse-pam/expect", ["expect-su.expect"])],
+
         install_requires=[
             "Twisted>=8.0.0",
             "python-pam"


### PR DESCRIPTION
For me, PAM is happy to let a user autenticate as the same user, but not as anyone else. So to stop running Synapse as root I added support for using `expect` and `su` instead. Works for me with Synapse 0.99.0.